### PR TITLE
fix(k8s): auto-refresh node-SA client token (refresh_api_key_hook)

### DIFF
--- a/src/adam_dagster_shared/k8s.py
+++ b/src/adam_dagster_shared/k8s.py
@@ -29,6 +29,21 @@ def get_node_sa_kubernetes_client(project_id, zone, cluster_id) -> client.ApiCli
     configuration.api_key["authorization"] = creds.token
     configuration.client_side_validation = False
 
+    # Auto-refresh the GCP OAuth token before each request. The kubernetes client
+    # invokes refresh_api_key_hook(configuration) inside get_api_key_with_prefix()
+    # ahead of every API call. google.auth's creds.valid is False once the token
+    # has expired (or is within the refresh skew), so we only hit the token
+    # endpoint when a refresh is actually needed. Without this hook the token
+    # fetched above is frozen into configuration.api_key, so a long-lived client
+    # (e.g. the sharded poll loop's read_namespaced_job calls) starts returning
+    # 401 once that token's TTL elapses.
+    def _refresh_api_key(config: client.Configuration) -> None:
+        if not creds.valid:
+            creds.refresh(auth_req)
+        config.api_key["authorization"] = creds.token
+
+    configuration.refresh_api_key_hook = _refresh_api_key
+
     # Return the ApiClient while the temporary file is still open
     return client.ApiClient(configuration)
 

--- a/tests/test_k8s_token_refresh.py
+++ b/tests/test_k8s_token_refresh.py
@@ -1,0 +1,75 @@
+"""Regression test: the node-SA k8s client must auto-refresh its bearer token.
+
+Without refresh_api_key_hook the GCP token fetched at client creation is frozen
+into Configuration.api_key, so a long-lived client (e.g. the precovery-v2
+sharded poll loop) returns 401 once that token's TTL elapses.
+"""
+import base64
+
+import google.auth.transport.requests  # noqa: F401 (ensure submodule importable)
+import adam_dagster_shared.k8s as k8s
+
+
+class _FakeCreds:
+    def __init__(self):
+        self.token = "tok-init"
+        self._valid = True
+        self.refreshes = 0
+
+    @property
+    def valid(self):
+        return self._valid
+
+    def refresh(self, _req):
+        self.refreshes += 1
+        self.token = f"tok-refreshed-{self.refreshes}"
+        self._valid = True
+
+
+class _FakeMasterAuth:
+    cluster_ca_certificate = base64.b64encode(b"FAKE-CA").decode()
+
+
+class _FakeClusterResp:
+    endpoint = "10.0.0.1"
+    master_auth = _FakeMasterAuth()
+
+
+class _FakeClusterManagerClient:
+    def get_cluster(self, project_id, zone, cluster_id):
+        return _FakeClusterResp()
+
+
+def test_refresh_api_key_hook_refreshes_on_expiry():
+    fake_creds = _FakeCreds()
+    orig_cmc = k8s.container_v1.ClusterManagerClient
+    orig_default = k8s.google.auth.default
+    k8s.container_v1.ClusterManagerClient = lambda *a, **k: _FakeClusterManagerClient()
+    k8s.google.auth.default = lambda *a, **k: (fake_creds, "proj")
+    try:
+        api = k8s.get_node_sa_kubernetes_client("p", "z", "c")
+        cfg = api.configuration
+
+        # hook is wired
+        assert cfg.refresh_api_key_hook is not None
+        # one refresh happened at construction; token snapshot reflects it
+        assert fake_creds.refreshes == 1, fake_creds.refreshes
+        assert cfg.api_key["authorization"] == "tok-refreshed-1"
+
+        # token expires -> hook re-fetches and updates api_key
+        fake_creds._valid = False
+        cfg.refresh_api_key_hook(cfg)
+        assert fake_creds.refreshes == 2, fake_creds.refreshes
+        assert cfg.api_key["authorization"] == "tok-refreshed-2"
+
+        # still valid -> hook is a no-op (no extra token-endpoint calls)
+        cfg.refresh_api_key_hook(cfg)
+        assert fake_creds.refreshes == 2, fake_creds.refreshes
+    finally:
+        k8s.container_v1.ClusterManagerClient = orig_cmc
+        k8s.google.auth.default = orig_default
+
+
+if __name__ == "__main__":
+    test_refresh_api_key_hook_refreshes_on_expiry()
+    print("PASS: refresh_api_key_hook refreshes on expiry, skips while valid")


### PR DESCRIPTION
## Problem

`get_node_sa_kubernetes_client` fetches the GCP OAuth token **once** and freezes
`creds.token` into `Configuration.api_key`. With no `refresh_api_key_hook`, a
long-lived client reuses that token forever and **401s once it expires**.

Observed on a precovery-v2 sharded GX82 run (`d41cca5b…`): the poll op
(`poll_precovery_v2_shards` → `read_namespaced_job` loop) progressed to **18/24**
shards, then hit `kubernetes.client.exceptions.ApiException: (401)` at ~8 min
(the run pod's workload-identity token TTL) → poll crashed → `finalize` was
skipped → the API job was stuck `RUNNING` even though every shard's detection
fragments and cutouts had already been written to GCS.

## Fix

Set `configuration.refresh_api_key_hook` to refresh the credentials when
`creds.valid` is false and re-copy the token into `api_key` before each request.
The kubernetes client calls this hook inside `get_api_key_with_prefix()` ahead
of every API call; the `creds.valid` gate keeps it cheap (only refreshes when
the token is actually expiring). This fixes **all** callers of the helper
(plan / poll / finalize / launcher), not just the sharded poll loop.

## Test

`tests/test_k8s_token_refresh.py` — verifies the hook is wired, refreshes when
the token is invalid (updating `api_key`), and is a no-op while the token is
still valid. Passes.

## Deploy note

Consumers pin this library by SHA (e.g. `adam-jobs/pyproject.toml`, currently
`@4ba8817`). After merge, re-pin to the new SHA and rebuild to pick up the fix.

Tracked in bead `personal-rzr`.
