### PR TITLE
Add scoped workload credentials and delegated job submission

### DIFF
--- a/src/adam_dagster_shared/adam_api_client.py
+++ b/src/adam_dagster_shared/adam_api_client.py
@@ -342,6 +342,81 @@ class ADAMAPIClient:
         """
         return self._make_request(endpoint, "DELETE")
 
+    @staticmethod
+    def workload_credential() -> Optional[str]:
+        """Dedicated least-privilege machine credential, when provisioned.
+
+        Sourced from ``ADAM_API_WORKLOAD_CREDENTIAL`` (mounted from a K8s
+        Secret in cluster deployments). ``None`` means the caller should use
+        the legacy refresh-token identity.
+        """
+        value = (os.getenv("ADAM_API_WORKLOAD_CREDENTIAL") or "").strip()
+        return value or None
+
+    def post_with_workload(
+        self, endpoint: str, data: Optional[Dict[str, Any]] = None
+    ) -> Optional[requests.Response]:
+        """POST to an internal endpoint as the workload principal.
+
+        Returns ``None`` when no workload credential is configured so callers
+        can fall back to the legacy identity explicitly.
+        """
+        credential = self.workload_credential()
+        if credential is None:
+            return None
+        url = f"{self.base_url.rstrip('/')}/{endpoint.lstrip('/')}"
+        return self.session.request(
+            method="POST",
+            url=url,
+            json=data,
+            headers={"Authorization": f"Workload {credential}"},
+        )
+
+    def post_with_delegation(
+        self,
+        endpoint: str,
+        data: Optional[Dict[str, Any]],
+        delegation_token: str,
+    ) -> requests.Response:
+        """POST to a public endpoint AS the delegated origin user/org."""
+        url = f"{self.base_url.rstrip('/')}/{endpoint.lstrip('/')}"
+        return self.session.request(
+            method="POST",
+            url=url,
+            json=data,
+            headers={"Authorization": f"Delegation {delegation_token}"},
+        )
+
+    def request_job_delegation(
+        self,
+        origin_job_id: str,
+        scopes: list[str],
+        ttl_seconds: int = 600,
+    ) -> Optional[str]:
+        """Mint a short-lived single-use delegation from an origin job.
+
+        The server derives the user/organization from the origin job; this
+        client can never choose them. Returns ``None`` when the workload
+        credential is not configured or issuance fails (callers fall back to
+        the legacy automation identity and log the attribution gap).
+        """
+        response = self.post_with_workload(
+            f"/api/internal/jobs/{origin_job_id}/delegations/",
+            {"scopes": list(scopes), "ttl_seconds": int(ttl_seconds)},
+        )
+        if response is None:
+            return None
+        if response.status_code != 200:
+            logging.warning(
+                "Job delegation issuance failed origin_job_id=%s status=%s body=%s",
+                origin_job_id,
+                response.status_code,
+                response.text[:200],
+            )
+            return None
+        token = response.json().get("token")
+        return token if isinstance(token, str) and token else None
+
     def authenticate_with_refresh_token(self, refresh_token: str) -> bool:
         """Authenticate using a refresh token to get an access token.
 
@@ -494,6 +569,17 @@ def create_authenticated_adam_api_client() -> ADAMAPIClient:
     encoded_token = secret.data[secret_key]
     refresh_token = base64.b64decode(encoded_token).decode("utf-8")
 
+    # Optional least-privilege workload credential (personal-rqe.3), delivered
+    # through the SAME secret so no new mounts/hard dependencies are added.
+    # An explicit ADAM_API_WORKLOAD_CREDENTIAL env var always wins; absence of
+    # the key simply keeps the legacy refresh-token identity.
+    workload_encoded = (secret.data or {}).get("workload-credential")
+    if workload_encoded and not os.getenv("ADAM_API_WORKLOAD_CREDENTIAL"):
+        os.environ["ADAM_API_WORKLOAD_CREDENTIAL"] = base64.b64decode(
+            workload_encoded
+        ).decode("utf-8")
+        logging.info("Loaded workload credential from dagster-adam-api-token secret")
+
     # Initialize and return API client with the refresh token
     client = initialize_adam_api_client(refresh_token=refresh_token)
     logging.info("Successfully initialized ADAM API client with refresh token")
@@ -582,20 +668,40 @@ def send_job_update(
         url = f"{api_client.base_url}/api/internal/job-update"
         headers = {"Content-Type": "application/json"}
 
-        # Get initial token if needed
-        if api_client.refresh_token and not api_client._access_token:
-            api_client._refresh_access_token()
-        if api_client._access_token:
-            headers["Authorization"] = f"Bearer {api_client._access_token}"
+        # Prefer the dedicated least-privilege workload credential; the
+        # legacy staff refresh token remains the transitional fallback.
+        workload_credential = api_client.workload_credential()
+        if workload_credential:
+            headers["Authorization"] = f"Workload {workload_credential}"
+        else:
+            # Get initial token if needed
+            if api_client.refresh_token and not api_client._access_token:
+                api_client._refresh_access_token()
+            if api_client._access_token:
+                headers["Authorization"] = f"Bearer {api_client._access_token}"
 
         # Make request
         response = requests.post(url, json=job_update_data, headers=headers)
 
         # Retry on 401 (Unauthorized) or 400 (Bad Request with auth errors)
-        if response.status_code in [400, 401] and api_client.refresh_token:
+        if (
+            response.status_code in [400, 401]
+            and not workload_credential
+            and api_client.refresh_token
+        ):
             logging.info(f"Token expired for job {job_id}, refreshing and retrying...")
             api_client._access_token = None
             if api_client._refresh_access_token():
+                headers["Authorization"] = f"Bearer {api_client._access_token}"
+                response = requests.post(url, json=job_update_data, headers=headers)
+        elif response.status_code in [401, 403] and workload_credential:
+            # Transitional resilience: a not-yet-seeded credential must not
+            # freeze job updates while the legacy token still works.
+            logging.warning(
+                "Workload credential rejected for job update %s; retrying legacy",
+                job_id,
+            )
+            if api_client.refresh_token and api_client._refresh_access_token():
                 headers["Authorization"] = f"Bearer {api_client._access_token}"
                 response = requests.post(url, json=job_update_data, headers=headers)
 

--- a/src/adam_dagster_shared/k8s.py
+++ b/src/adam_dagster_shared/k8s.py
@@ -29,6 +29,21 @@ def get_node_sa_kubernetes_client(project_id, zone, cluster_id) -> client.ApiCli
     configuration.api_key["authorization"] = creds.token
     configuration.client_side_validation = False
 
+    # Auto-refresh the GCP OAuth token before each request. The kubernetes client
+    # invokes refresh_api_key_hook(configuration) inside get_api_key_with_prefix()
+    # ahead of every API call. google.auth's creds.valid is False once the token
+    # has expired (or is within the refresh skew), so we only hit the token
+    # endpoint when a refresh is actually needed. Without this hook the token
+    # fetched above is frozen into configuration.api_key, so a long-lived client
+    # (e.g. the sharded poll loop's read_namespaced_job calls) starts returning
+    # 401 once that token's TTL elapses.
+    def _refresh_api_key(config: client.Configuration) -> None:
+        if not creds.valid:
+            creds.refresh(auth_req)
+        config.api_key["authorization"] = creds.token
+
+    configuration.refresh_api_key_hook = _refresh_api_key
+
     # Return the ApiClient while the temporary file is still open
     return client.ApiClient(configuration)
 

--- a/tests/test_k8s_token_refresh.py
+++ b/tests/test_k8s_token_refresh.py
@@ -1,0 +1,75 @@
+"""Regression test: the node-SA k8s client must auto-refresh its bearer token.
+
+Without refresh_api_key_hook the GCP token fetched at client creation is frozen
+into Configuration.api_key, so a long-lived client (e.g. the precovery-v2
+sharded poll loop) returns 401 once that token's TTL elapses.
+"""
+import base64
+
+import google.auth.transport.requests  # noqa: F401 (ensure submodule importable)
+import adam_dagster_shared.k8s as k8s
+
+
+class _FakeCreds:
+    def __init__(self):
+        self.token = "tok-init"
+        self._valid = True
+        self.refreshes = 0
+
+    @property
+    def valid(self):
+        return self._valid
+
+    def refresh(self, _req):
+        self.refreshes += 1
+        self.token = f"tok-refreshed-{self.refreshes}"
+        self._valid = True
+
+
+class _FakeMasterAuth:
+    cluster_ca_certificate = base64.b64encode(b"FAKE-CA").decode()
+
+
+class _FakeClusterResp:
+    endpoint = "10.0.0.1"
+    master_auth = _FakeMasterAuth()
+
+
+class _FakeClusterManagerClient:
+    def get_cluster(self, project_id, zone, cluster_id):
+        return _FakeClusterResp()
+
+
+def test_refresh_api_key_hook_refreshes_on_expiry():
+    fake_creds = _FakeCreds()
+    orig_cmc = k8s.container_v1.ClusterManagerClient
+    orig_default = k8s.google.auth.default
+    k8s.container_v1.ClusterManagerClient = lambda *a, **k: _FakeClusterManagerClient()
+    k8s.google.auth.default = lambda *a, **k: (fake_creds, "proj")
+    try:
+        api = k8s.get_node_sa_kubernetes_client("p", "z", "c")
+        cfg = api.configuration
+
+        # hook is wired
+        assert cfg.refresh_api_key_hook is not None
+        # one refresh happened at construction; token snapshot reflects it
+        assert fake_creds.refreshes == 1, fake_creds.refreshes
+        assert cfg.api_key["authorization"] == "tok-refreshed-1"
+
+        # token expires -> hook re-fetches and updates api_key
+        fake_creds._valid = False
+        cfg.refresh_api_key_hook(cfg)
+        assert fake_creds.refreshes == 2, fake_creds.refreshes
+        assert cfg.api_key["authorization"] == "tok-refreshed-2"
+
+        # still valid -> hook is a no-op (no extra token-endpoint calls)
+        cfg.refresh_api_key_hook(cfg)
+        assert fake_creds.refreshes == 2, fake_creds.refreshes
+    finally:
+        k8s.container_v1.ClusterManagerClient = orig_cmc
+        k8s.google.auth.default = orig_default
+
+
+if __name__ == "__main__":
+    test_refresh_api_key_hook_refreshes_on_expiry()
+    print("PASS: refresh_api_key_hook refreshes on expiry, skips while valid")

--- a/tests/test_workload_delegation_client.py
+++ b/tests/test_workload_delegation_client.py
@@ -1,0 +1,104 @@
+"""Workload-credential and job-delegation client support (personal-rqe.2/.3)."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from adam_dagster_shared import adam_api_client as client_module
+from adam_dagster_shared.adam_api_client import ADAMAPIClient, send_job_update
+
+
+class _Response:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+def _client() -> ADAMAPIClient:
+    return ADAMAPIClient("api.example", 80)
+
+
+def test_workload_credential_absent_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("ADAM_API_WORKLOAD_CREDENTIAL", raising=False)
+    assert ADAMAPIClient.workload_credential() is None
+    assert _client().post_with_workload("/api/x", {}) is None
+
+
+def test_request_job_delegation_uses_workload_scheme(monkeypatch) -> None:
+    monkeypatch.setenv("ADAM_API_WORKLOAD_CREDENTIAL", "wl-secret")
+    client = _client()
+    captured: dict = {}
+
+    def _request(method, url, json=None, headers=None):
+        captured.update(method=method, url=url, json=json, headers=headers)
+        return _Response(200, {"token": "dgt_token"})
+
+    monkeypatch.setattr(client.session, "request", _request)
+    token = client.request_job_delegation("parent-1", ["jobs:create:cutout"])
+    assert token == "dgt_token"
+    assert captured["headers"]["Authorization"] == "Workload wl-secret"
+    assert captured["url"].endswith("/api/internal/jobs/parent-1/delegations/")
+    assert captured["json"] == {
+        "scopes": ["jobs:create:cutout"],
+        "ttl_seconds": 600,
+    }
+
+
+def test_request_job_delegation_failure_returns_none(monkeypatch) -> None:
+    monkeypatch.setenv("ADAM_API_WORKLOAD_CREDENTIAL", "wl-secret")
+    client = _client()
+    monkeypatch.setattr(
+        client.session,
+        "request",
+        lambda **kwargs: _Response(403, {}, "forbidden"),
+    )
+    assert client.request_job_delegation("parent-1", ["jobs:create:cutout"]) is None
+
+
+def test_post_with_delegation_sets_delegation_scheme(monkeypatch) -> None:
+    client = _client()
+    captured: dict = {}
+
+    def _request(method, url, json=None, headers=None):
+        captured.update(headers=headers, url=url)
+        return _Response(200, {"id": "child"})
+
+    monkeypatch.setattr(client.session, "request", _request)
+    response = client.post_with_delegation("/api/cutouts/", {"a": 1}, "dgt_x")
+    assert response.status_code == 200
+    assert captured["headers"]["Authorization"] == "Delegation dgt_x"
+
+
+def test_send_job_update_prefers_workload_credential(monkeypatch) -> None:
+    monkeypatch.setenv("ADAM_API_WORKLOAD_CREDENTIAL", "wl-secret")
+    client = _client()
+    monkeypatch.setattr(client_module, "get_adam_client", lambda: client)
+    captured: dict = {}
+
+    def _post(url, json=None, headers=None):
+        captured.update(url=url, headers=headers)
+        return _Response(200)
+
+    with mock.patch.object(client_module.requests, "post", side_effect=_post):
+        assert send_job_update(job_id="job-1", status="running") is True
+    assert captured["headers"]["Authorization"] == "Workload wl-secret"
+
+
+def test_send_job_update_falls_back_to_legacy_bearer(monkeypatch) -> None:
+    monkeypatch.delenv("ADAM_API_WORKLOAD_CREDENTIAL", raising=False)
+    client = ADAMAPIClient("api.example", 80, refresh_token="refresh")
+    client._access_token = "jwt-token"
+    monkeypatch.setattr(client_module, "get_adam_client", lambda: client)
+    captured: dict = {}
+
+    def _post(url, json=None, headers=None):
+        captured.update(headers=headers)
+        return _Response(200)
+
+    with mock.patch.object(client_module.requests, "post", side_effect=_post):
+        assert send_job_update(job_id="job-1", status="running") is True
+    assert captured["headers"]["Authorization"] == "Bearer jwt-token"


### PR DESCRIPTION
Adds least-privilege workload credential loading plus short-lived delegated request helpers used by the precovery cutout child rollout (personal-rqe.2/.3). Includes the node-SA Kubernetes token refresh fix already present semantically on main; this branch was based on its equivalent pre-PR commit. adam-jobs is pinned to commit 4f1ad12.